### PR TITLE
Fix/some changes for filter options interfaces

### DIFF
--- a/types/contract/contractFilter.d.ts
+++ b/types/contract/contractFilter.d.ts
@@ -6,6 +6,7 @@ export interface IContractFilterDate {
 export interface IContractFilterOptions {
   contractStates: IContractFilterOption[]
   templates: IContractFilterOption[]
+  options: IContractFilterOption[]
   sellers: IContractFilterOption[]
   created: IContractFilterDate
   expired: IContractFilterDate

--- a/types/contract/contractFilter.d.ts
+++ b/types/contract/contractFilter.d.ts
@@ -1,6 +1,6 @@
 export interface IContractFilterDate {
-  start: Date
-  end: Date
+  start: string
+  end: string
 }
 
 export interface IContractFilterOptions {


### PR DESCRIPTION
* Dates can not be JS Dates - we send strings in the service back and forth. Conversion to JS date is a view issue.
* We forgot about adding options as per discussion with Rasmus