### PR TITLE
added a new interface to export for the duration options

### DIFF
--- a/types/durationOptions.d.ts
+++ b/types/durationOptions.d.ts
@@ -1,11 +1,13 @@
 import { PriceSpecification } from './priceSpecification'
 
+export interface DurationOptionsOptionsPrices {
+  contractId: number
+  price: PriceSpecification
+}
+
 export interface DurationOptionsOptions {
   mileage: number
-  prices: {
-    contractId: number
-    price: PriceSpecification
-  }[]
+  prices: DurationOptionsOptionsPrices[]
 }
 
 export interface DurationOptions {

--- a/types/durationOptions.d.ts
+++ b/types/durationOptions.d.ts
@@ -1,12 +1,14 @@
 import { PriceSpecification } from './priceSpecification'
 
-export interface DurationOptions {
-  options: {
-    mileage: number
-    prices: {
-      contractId: number
-      price: PriceSpecification
-    }[]
+export interface DurationOptionsOptions {
+  mileage: number
+  prices: {
+    contractId: number
+    price: PriceSpecification
   }[]
+}
+
+export interface DurationOptions {
+  options: DurationOptionsOptions[]
   duration: number
 }


### PR DESCRIPTION
Why this interface is called DurationOptions I do not know

Now that I needed a interface for the actual options inside it - that is now called IDurationOptionsOptions

Why not just have called the original interface IDuration?