### PR TITLE
event translations/ContractActionType enums

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -33,7 +33,12 @@ export enum AggregateType {
 }
 
 export enum FormattingLocale {
-  'sv-SE', 'uk-UA', 'da-DK', 'en-GB', 'fi-FI', 'en-US'
+  'sv-SE',
+  'uk-UA',
+  'da-DK',
+  'en-GB',
+  'fi-FI',
+  'en-US',
 }
 
 export enum ContractActionType {
@@ -42,9 +47,15 @@ export enum ContractActionType {
   buyNow = 130, // Customer visited payment page
   createOffer = 140, // An offer was created
   sendOfferReminderMail = 150, // A reminder about offer was sent to the customer
+  sendContractTerminationMail = 151, // A termination mail was sent to the customer
   sendOfferReminderMail2 = 152, // A reminder about offer was sent to the customer
+  sendContractActivationMail = 153, // A contract activation mail was sent to the customer
   sendOfferReminderMail3 = 154, // A reminder about offer was sent to the customer
+  sendContractSuspendedMail = 155, // A suspended mail was sent to the customer
   sendContractOfferMail = 156, // A contract offer was sent to the customer
+  sendContractReactivationMail = 157, // A contract reactivation mail was sent to the customer
+  sendContractAdjustmentMail = 158, // A contract adjustment mail was sent to the customer
+  sendContractSettlementMail = 159, // A contract settlement mail was sent to the customer
   rejectOffer = 160, // The customer rejected the offer
   acceptOffer = 180, // The customer accepted the offer
   approveOffer = 200, // Who approved it? that would be the customer
@@ -58,6 +69,7 @@ export enum ContractActionType {
   reactivate = 700, // Who unsuspended the contract
   terminate = 800, // Who terminated the contract
   settle = 900, // Who Settled the contract, any settlement comments will be in the details
+  archive = 1000, // Archive contract
 }
 
 export enum OfferRequestState {
@@ -74,7 +86,7 @@ export enum ResponseWarnings {
 export type FileUploadToStorageType = 'General-Storage' | 'Logo-Banner-Storage' | 'Logo-Square-Storage'
 
 export enum WarrantyOnboardingConfig {
-  interdan = "Interdan"
+  interdan = 'Interdan',
 }
 
 export * from './address'


### PR DESCRIPTION
There's a pull request in SAM-api that's connected to this pull request.

Some event types in the list of events on the page for a contract did not get translations and only showed a number instead (which enum they belonged to). These event types are added to SAM-types so they will get translated as well now. 

Related to this, SAM-types have an enum called ContractActionType and SAM-api have an enum called ServiceContractActionType. They contain the same values so ServiceContractActionType is now removed and all references point to ContractActionType instead to only have one source for this enum so the enum is always the same everywhere.