### PR TITLE
all included options did not show on the customer portal

### DIFF
--- a/types/admin/vehicle/vehicle.d.ts
+++ b/types/admin/vehicle/vehicle.d.ts
@@ -1,4 +1,4 @@
-import { ContractState } from './../../index'
+import { ContractState, IIncludedContractOption } from './../../index'
 import { PaymentGateway } from './../../payment'
 import { PriceSpecification } from './../../priceSpecification'
 
@@ -23,7 +23,7 @@ export interface IApiVehicleContract {
   contractState: ContractState
   prettyIdentifier: string
   pdfUrl: string
-  includedOptions: IApiVehicleIncludedContractOption[]
+  includedOptions: IIncludedContractOption[]
   contractTemplateName: string
   duration: number
   mileage: number


### PR DESCRIPTION
I've explained the changes here:
https://fragus-it.monday.com/boards/467282465/pulses/1122496610

There is a commit on admin, api and sam-types. I guess sam-types would have to be merged first as usual so sam-types can be bumped in admin and api after.